### PR TITLE
Calculate thermal conductivity and estimate diagnostic quantities

### DIFF
--- a/src/consts.jl
+++ b/src/consts.jl
@@ -44,13 +44,21 @@ module consts
     const αMLT::Float64 = 1.0
     export αMLT
 
+    # Convection beta parameter for obtaining Ra, dimensionless
+    const βRa::Float64 = 0.25
+    export βRa
+
     # Newton's gravitational constant [m3 kg-1 s-2]
     const G_grav::Float64 = 6.67430e-11 # NIST CODATA
     export G_grav
 
     # Specific heat capacity for ideal gas [J mol-1 K-1]
-    const Cp_ideal::Float64 = 29.10   # = 7/2 R_gas, assuming that it is diatomic
+    const Cp_ideal::Float64 = R_gas * 7/2 # assuming that it is diatomic
     export Cp_ideal
+
+    # Proton mass [kg]
+    const proton_mass::Float64 = 1.67262192595e-27 # NIST CODATA
+    export proton_mass
 
     # List of elements included in the model
     const elems_standard::Array{String,1} = ["H","C","N","O","S","P","He",


### PR DESCRIPTION
* Calculates thermal conductivity, assuming diatomic gas
* Allows user to enable calculation of  conductive heat flux (closes #133)
* Estimates the Rayleigh number at each layer (closes #131)
* Estimates the radiative and convective timescales in each layer 

Version 1.7.3