### PR TITLE
Option for turning cloud radiative properties off

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AGNI"
 uuid = "ede838c1-9ec3-4ebe-8ae8-da4091b3f21c"
 authors = ["Harrison Nicholls <harrison.nicholls@physics.ox.ac.uk>"]
-version = "1.7.3"
+version = "1.7.4"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AGNI"
 uuid = "ede838c1-9ec3-4ebe-8ae8-da4091b3f21c"
 authors = ["Harrison Nicholls <harrison.nicholls@physics.ox.ac.uk>"]
-version = "1.7.4"
+version = "1.7.5"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/codemeta.json
+++ b/codemeta.json
@@ -19,5 +19,5 @@
   "keywords": "physics, radiative transfer, exoplanets, astronomy, convection, radiation, planets, atmospheres",
   "license": "GPL v3.0",
   "title": "AGNI",
-  "version": "1.7.4"
+  "version": "1.7.5"
 }

--- a/codemeta.json
+++ b/codemeta.json
@@ -19,5 +19,5 @@
   "keywords": "physics, radiative transfer, exoplanets, astronomy, convection, radiation, planets, atmospheres",
   "license": "GPL v3.0",
   "title": "AGNI",
-  "version": "1.7.3"
+  "version": "1.7.4"
 }

--- a/docs/src/usage.md
+++ b/docs/src/usage.md
@@ -115,7 +115,7 @@ Atmospheric composition and chemistry.
 | `p_dict        `  | Dictionary of gas partial surface pressures [bar]. Summed to obtain `p_surf`. |
 | `p_surf        `  | Total surface pressure [bar]. Incompatible with `p_dict`.|
 | `vmr_dict      `  | Gas volume mixing ratios (=mole fractions) at the surface. Must be set alongside `p_surf`. |
-| `vmr_file      `  | Path to a file containing mixing ratio profiles. Replaces `vmr_dict`. |
+| `vmr_file      `  | Path to a file containing mixing ratio profiles. Replaces `vmr_dict`. Must be set alongside `p_surf`. |
 | `chemistry     `  | Type of chemistry to be used (see below). |
 | `condensates   `  | List of volatiles which are allowed to condense. Incompatible with `chemistry > 0`. |
 | `transparent   `  | Make the atmosphere transparent (see below). Replaces all of the above parameters in this table. |

--- a/res/config/default.toml
+++ b/res/config/default.toml
@@ -30,7 +30,6 @@ title = "Default"                       # Name for this configuration file
     p_surf          = 270.0                     # Total surface pressure [bar].
     p_top           = 1e-5                      # Total top-of-atmosphere pressure [bar].
     vmr_dict        = { H2O=1.0 }               # Volatile volume mixing ratios (=mole fractions).
-    vmr_file        = ""                        # Path to input volume mixing ratios. Not required if planet.vmr is passed.
     chemistry       = 0                         # Chemistry type (see wiki).
     condensates     = []                        # List of volatiles which are allowed to condense.
 

--- a/res/config/hotdry.toml
+++ b/res/config/hotdry.toml
@@ -24,7 +24,6 @@ title = "Hot and dry"
     p_surf          = 2700.0
     p_top           = 1e-5
     vmr_dict        = { H2O = 1.0}
-    vmr_file        = ""
     chemistry       = 0
     condensates     = []
 

--- a/res/config/k218b.toml
+++ b/res/config/k218b.toml
@@ -24,7 +24,6 @@ title = "K2-18 b, mixed"
     p_surf          = 10e3
     p_top           = 1e-5
     vmr_dict        = { H2O=0.424, H2=0.433, CO2=0.0715, CH4=0.0715 }
-    vmr_file        = ""
     chemistry       = 0
     condensates     = ["H2O","CO2","CH4"]
 

--- a/res/config/l9859d.toml
+++ b/res/config/l9859d.toml
@@ -24,7 +24,6 @@ title = "L 98-59 d"
     p_surf          = 32.89e3
     p_top           = 1e-4
     vmr_dict        = { SO2=1.0 }
-    vmr_file        = ""
     chemistry       = 0
     condensates     = []
 

--- a/src/AGNI.jl
+++ b/src/AGNI.jl
@@ -256,9 +256,17 @@ module AGNI
                 if haskey(cfg["composition"],"vmr_dict")
                     # from dict in cfg file
                     mf_dict = cfg["composition"]["vmr_dict"]
-                elseif haskey(cfg["composition"], "vmr_path")
+
+                    # don't allow both keys
+                    if haskey(cfg["composition"], "vmr_file")
+                        @error "Misconfiguration: cannot provide `vmr_file` and `vmr_dict`"
+                        return false
+                    end
+
+                elseif haskey(cfg["composition"], "vmr_file")
                     # from csv file to be read-in
                     mf_path = cfg["composition"]["vmr_file"]
+
                 else
                     @error "Misconfiguration: if providing p_surf, must also provide VMRs"
                     return false
@@ -276,9 +284,13 @@ module AGNI
                     mf_dict[k] = pp_dict[k]/p_surf
                 end
 
+                if haskey(cfg["composition"], "vmr_file") || haskey(cfg["composition"], "vmr_dict")
+                    @error "Misconfiguration: cannot provide partial pressures and mixing ratios"
+                end
+
             # most provide either VMR or partial pressures, if not transparent
             else
-                @error "Must provide either p_dict or p_surf+VMRs in config"
+                @error "Must provide either p_dict OR p_surf+VMRs in config"
                 @error "    Neglect these keys only when transparent=true"
                 return false
             end

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -34,7 +34,7 @@ module atmosphere
     import ..spectrum
 
     # Constants
-    const AGNI_VERSION::String   = "1.7.3"
+    const AGNI_VERSION::String   = "1.7.4"
     const HYDROGRAV_STEPS::Int64 = 40
 
     # Contains data pertaining to the atmosphere (fluxes, temperature, etc.)
@@ -612,40 +612,47 @@ module atmosphere
             mf_head::String =   readline(abspath(mf_path))
 
             # remove comment symbol at start
-            mf_head =           mf_head[2:end]
+            mf_head = mf_head[2:end]
 
             # remove whitespace
-            mf_head =            replace(mf_head, " " => "")
+            mf_head = replace(mf_head, " " => "")
 
             # split by column and drop first three
-            heads::Array{String,1} = split(mf_head, ",")[4:end]
-
-            # create arrays
-            for h in heads
-                gas_valid = strip(h, [' ','\t','\n'])
-                # Check if repeated
-                if !(gas_valid in atmos.gas_names)
-                    # Store zero VMR for now
-                    atmos.gas_vmr[gas_valid] = zeros(Float64, atmos.nlev_c)
-                    push!(atmos.gas_names, gas_valid)
-                    atmos.gas_num += 1
-                end
-            end
+            heads::Array{String,1} = split(mf_head, ",")[1:end]
 
             # get body
             mf_body::Array{Float64,2} = readdlm(abspath(mf_path), ',', Float64;
                                                 header=false, skipstart=2)
             mf_body = transpose(mf_body)
 
-            # set composition by interpolating with pressure array
-            gidx::Int=0
-            for li in 4:lastindex(heads)
-                # Gas index
-                gidx += 1
+            # Get pressure array from file
+            arr_p::Array{Float64,1} = mf_body[1,:]
+            arr_x::Array{Float64,1} = zero(arr_p)
 
-                # Arrays from file
-                arr_p::Array{Float64,1} = mf_body[1,:]
-                arr_x::Array{Float64,1} = mf_body[li,:]
+            # set composition by interpolating with pressure array
+            # the pressure array must be the first column in the file
+            for li in 2:lastindex(heads)
+                gas = strip(heads[li], [' ','\t','\n'])
+
+                # Check if this gas is repeated, or contains invalid chars
+                if gas in atmos.gas_names
+                    @warn "VMR file contains repeated gas '$gas'"
+                    continue
+
+                elseif !occursin(r"^[[:alnum:]]*$", gas)
+                    @warn "VMR file contains invalid gas '$gas'"
+                    continue
+
+                else
+                    # Store with zero VMR
+                    atmos.gas_vmr[gas] = zeros(Float64, atmos.nlev_c)
+                    push!(atmos.gas_names, gas)
+                    @debug "    added $gas"
+                    atmos.gas_num += 1
+                end
+
+                # Get VMR values from file
+                arr_x[:] .= mf_body[li,:]
 
                 # Extend loaded profile to lower pressures (prevents domain error)
                 if arr_p[1] > atmos.p_toa
@@ -664,7 +671,7 @@ module atmosphere
 
                 # Set values in atmos struct
                 for i in 1:atmos.nlev_c
-                    atmos.gas_vmr[atmos.gas_names[gidx]][i] = itp(log10(atmos.p[i]))
+                    atmos.gas_vmr[gas][i] = itp(log10(atmos.p[i]))
                 end
             end
 

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -34,7 +34,7 @@ module atmosphere
     import ..spectrum
 
     # Constants
-    const AGNI_VERSION::String    = "1.7.4"  # current agni version
+    const AGNI_VERSION::String    = "1.7.5"  # current agni version
     const HYDROGRAV_STEPS::Int64  = 40       # num of sub-layers in hydrostatic integration
     const SOCVER_minimum::Float64 = 2407.2   # minimum required socrates version
 

--- a/src/chemistry.jl
+++ b/src/chemistry.jl
@@ -256,7 +256,7 @@ module chemistry
         atmosphere.calc_layer_props!(atmos)
 
         # Set water clouds at levels where condensation occurs
-        if ("H2O" in atmos.condensates) && atmos.control.l_cloud
+        if "H2O" in atmos.condensates
             for i in 1:atmos.nlev_c-1
                 if atmos.cond_yield["H2O"][i] > 0.0
                     # liquid water content (take ratio of mass surface densities [kg/m^2])

--- a/src/energy.jl
+++ b/src/energy.jl
@@ -135,9 +135,15 @@ module energy
         # Cloud information
         ###################################################
 
-        atmos.cld.w_cloud[1,:]               .= atmos.cloud_arr_f[:]    # Total cloud area fraction in layers
-        atmos.cld.condensed_mix_ratio[1,:,1] .= atmos.cloud_arr_l[:]    # Mass mixing ratios of condensate
-        atmos.cld.condensed_dim_char[1,:,1]  .= atmos.cloud_arr_r[:]    # Characteristic dimensions of condensed species
+        if atmos.control.l_cloud
+            atmos.cld.w_cloud[1,:]               .= atmos.cloud_arr_f[:]    # Total cloud area fraction in layers
+            atmos.cld.condensed_mix_ratio[1,:,1] .= atmos.cloud_arr_l[:]    # Mass mixing ratios of condensate
+            atmos.cld.condensed_dim_char[1,:,1]  .= atmos.cloud_arr_r[:]    # Characteristic dimensions of condensed species
+        else
+            atmos.cld.w_cloud[1,:]               .= 0.0
+            atmos.cld.condensed_mix_ratio[1,:,1] .= 0.0
+            atmos.cld.condensed_dim_char[1,:,1]  .= 0.0
+        end
 
         ###################################################
         # Treatment of scattering


### PR DESCRIPTION
Can calculate cloud location and mass mixing ratios, but ignore their radiative properties. This is useful for determining where clouds *might* form in a given climate, but without the sensitivity to their SW scattering and LW opacity.

Also contains fixes which allow reading VMRs from a csv file.

Version 1.7.5