### PR TITLE
Expose more solver options to user

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AGNI"
 uuid = "ede838c1-9ec3-4ebe-8ae8-da4091b3f21c"
 authors = ["Harrison Nicholls <harrison.nicholls@physics.ox.ac.uk>"]
-version = "1.7.6"
+version = "1.7.7"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/codemeta.json
+++ b/codemeta.json
@@ -19,5 +19,5 @@
   "keywords": "physics, radiative transfer, exoplanets, astronomy, convection, radiation, planets, atmospheres",
   "license": "GPL v3.0",
   "title": "AGNI",
-  "version": "1.7.6"
+  "version": "1.7.7"
 }

--- a/res/config/55cnce_chem.toml
+++ b/res/config/55cnce_chem.toml
@@ -5,8 +5,8 @@ title = "Roughly 55 Cancri e @ fO2=IW"
     tmp_surf        = 2700.0
     instellation    = 3.3231e6
     albedo_b        = 0.0
-    s0_fact         = 0.6652
-    zenith_angle    = 60.0
+    s0_fact         = 1.0 #0.6652
+    zenith_angle    = 0.0 #60.0
     surface_material= "res/surface_albedos/basalttuff.dat"
     radius          = 1.1959e7
     gravity         = 22.304
@@ -26,7 +26,7 @@ title = "Roughly 55 Cancri e @ fO2=IW"
     condensates     = []
 
 [execution]
-    clean_output    = true
+    clean_output    = false
     verbosity       = 1
     max_steps       = 20000
     max_runtime     = 400
@@ -46,7 +46,7 @@ title = "Roughly 55 Cancri e @ fO2=IW"
     solution_type   = 3
     solver          = "newton"
     dx_max          = 400.0
-    initial_state   = ["iso", "2700"]
+    initial_state   = ["iso","2000"] #["ncdf", "out/atm.nc"]
     linesearch      = 0
     easy_start      = false
     converge_atol   = 1.0e-2

--- a/res/config/55cnce_chem.toml
+++ b/res/config/55cnce_chem.toml
@@ -26,7 +26,7 @@ title = "Roughly 55 Cancri e @ fO2=IW"
     condensates     = []
 
 [execution]
-    clean_output    = false
+    clean_output    = true
     verbosity       = 1
     max_steps       = 20000
     max_runtime     = 400

--- a/src/AGNI.jl
+++ b/src/AGNI.jl
@@ -320,15 +320,9 @@ module AGNI
         end
 
         #    chemistry
-        if chem_type in [1,2,3]
-            if length(condensates)>0
-                @error "Config: chemistry is incompatible with condensation"
-                return false
-            end
-            if transparent
-                @error "Config: chemistry is incompatible with transparent atmosphere mode"
-                return false
-            end
+        if (chem_type > 0) && transparent
+            @error "Config: chemistry is incompatible with transparent atmosphere mode"
+            return false
         end
 
         #    RFM radtrans

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -34,7 +34,7 @@ module atmosphere
     import ..spectrum
 
     # Constants
-    const AGNI_VERSION::String    = "1.7.6"  # current agni version
+    const AGNI_VERSION::String    = "1.7.7"  # current agni version
     const HYDROGRAV_STEPS::Int64  = 40       # num of sub-layers in hydrostatic integration
     const SOCVER_minimum::Float64 = 2407.2   # minimum required socrates version
 

--- a/src/chemistry.jl
+++ b/src/chemistry.jl
@@ -306,6 +306,10 @@ module chemistry
     """
     function fastchem_eqm!(atmos::atmosphere.Atmos_t, chem_type::Int, write_cfg::Bool)::Int
 
+        if chem_type == 0
+            return 0
+        end 
+
         @debug "Running equilibrium chemistry"
 
         # Return code

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -114,9 +114,10 @@ module solver
     - `method::Int`                     numerical method (1: Newton-Raphson, 2: Gauss-Newton, 3: Levenberg-Marquardt)
     - `ls_method::Int`                  linesearch algorithm (0: None, 1: golden, 2: backtracking)
     - `easy_start::Bool`                improve convergence by introducing convection and phase change gradually
-    - `perturb_all::Bool`               always recalculate entire Jacobian matrix? Otherwise updates columns only as required
     - `ls_increase::Bool`               factor by which the cost can increase from last step before triggering linesearch
     - `detect_plateau::Bool`            assist solver when it is stuck in a region of small dF/dT
+    - `perturb_all::Bool`               always recalculate entire Jacobian matrix? Otherwise updates columns only as required
+    - `perturb_chem::Bool`              include chemistry calculation during finite-difference construction of jacobian
     - `modplot::Int`                    iteration frequency at which to make plots
     - `save_frames::Bool`               save plotting frames
     - `modprint::Int`                   iteration frequency at which to print info
@@ -138,6 +139,7 @@ module solver
                             method::Int=1, ls_method::Int=1, easy_start::Bool=false,
                             ls_increase::Float64=1.08,
                             detect_plateau::Bool=true, perturb_all::Bool=true,
+                            perturb_chem::Bool=false,
                             modplot::Int=1, save_frames::Bool=true,
                             modprint::Int=1, plot_jacobian::Bool=true,
                             conv_atol::Float64=1.0e-2, conv_rtol::Float64=1.0e-3
@@ -272,6 +274,13 @@ module solver
 
             # Set new temperatures
             _set_tmps!(x)
+
+            # Do chemistry?
+            if perturb_chem && (chem_type in [1,2,3])
+                if chemistry.fastchem_eqm!(atmos, chem_type, false) != 0
+                    return false
+                end
+            end
 
             # Calculate fluxes
             energy.calc_fluxes!(atmos, true,

--- a/src/solver.jl
+++ b/src/solver.jl
@@ -115,6 +115,8 @@ module solver
     - `ls_method::Int`                  linesearch algorithm (0: None, 1: golden, 2: backtracking)
     - `easy_start::Bool`                improve convergence by introducing convection and phase change gradually
     - `ls_increase::Bool`               factor by which the cost can increase from last step before triggering linesearch
+    - `ls_max_steps::Int`               maximum steps undertaken by linesearch routine
+    - `ls_min_scale::Float64`           minimum step scale allowed after linesearch
     - `detect_plateau::Bool`            assist solver when it is stuck in a region of small dF/dT
     - `perturb_all::Bool`               always recalculate entire Jacobian matrix? Otherwise updates columns only as required
     - `perturb_chem::Bool`              include chemistry calculation during finite-difference construction of jacobian
@@ -138,6 +140,7 @@ module solver
                             fdw::Float64=3.0e-5, fdc::Bool=true, fdo::Int=2,
                             method::Int=1, ls_method::Int=1, easy_start::Bool=false,
                             ls_increase::Float64=1.08,
+                            ls_max_steps::Int=20, ls_min_scale::Float64 = 1.0e-5,
                             detect_plateau::Bool=true, perturb_all::Bool=true,
                             perturb_chem::Bool=false,
                             modplot::Int=1, save_frames::Bool=true,
@@ -189,8 +192,6 @@ module solver
 
         #    linesearch
         ls_tau::Float64    =    0.7     # backtracking downscale size
-        ls_max_steps::Int  =    20      # maximum steps
-        ls_min_scale::Float64 = 1.0e-5  # minimum scale
 
         #    plateau
         plateau_n::Int =        4       # Plateau declared when plateau_i > plateau_n


### PR DESCRIPTION
* Exposes more solver options to `solve_energy!` function parameters 
* Allows chemistry and rainout/evaporation schemes to be enabled at the same time self-consistently (closes #125)

Version 1.7.7