### PR TITLE
Bugfix in convection formulation

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -10,7 +10,7 @@
     "contributors": [
     ],
     "title": "AGNI: An open-source model for extreme atmospheres on rocky exoplanets",
-    "version": "1.7.11",
+    "version": "1.7.12",
     "access_right": "open",
     "related_identifiers": [
         {

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,7 +10,7 @@ title: "AGNI: An open-source model for extreme atmospheres on rocky exoplanets"
 doi: 10.21105/joss.07726
 date-released: 2025-11-03
 
-version: 1.7.11
+version: 1.7.12
 url: "https://github.com/nichollsh/AGNI"
 type: software
 license: "GPL-3.0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "AGNI"
 uuid = "ede838c1-9ec3-4ebe-8ae8-da4091b3f21c"
 authors = ["Harrison Nicholls <harrison.nicholls@physics.ox.ac.uk>"]
-version = "1.7.11"
+version = "1.7.12"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/codemeta.json
+++ b/codemeta.json
@@ -19,5 +19,5 @@
   "keywords": "physics, radiative transfer, exoplanets, astronomy, convection, radiation, planets, atmospheres",
   "license": "GPL v3.0",
   "title": "AGNI",
-  "version": "1.7.11"
+  "version": "1.7.12"
 }

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -20,7 +20,8 @@ makedocs(
         "examples/index.md",
         "troubleshooting.md",
         "Development" => "manual/index.md",
-        "Related codes" => "ecosystem.md"
+        "Related codes" => "ecosystem.md",
+        "Contributors" => "contributors.md"
     ]
 )
 

--- a/docs/src/contributors.md
+++ b/docs/src/contributors.md
@@ -1,0 +1,12 @@
+# Contributors
+
+I would like to thank the following people for their assistance during the ongoing development of AGNI.
+
+* [Tim Lichtenberg](https://www.formingworlds.space/team/tim-lichtenberg)
+* [Raymond Pierrehumbert](https://users.physics.ox.ac.uk/~pierrehumbert/)
+* [Namrah Habib](https://www.physics.ox.ac.uk/our-people/habibn)
+* [Arjun Savel](https://www.arjunsavel.com/) -- JOSS paper reviewer
+* [Ryan Macdonald](https://distantworlds.space/) -- JOSS paper reviewer
+* [Boding Ouyang](https://github.com/OYBDOOO)
+
+Please contact [Harrison Nicholls](https://www.h-nicholls.space/) for any queries relating to AGNI.

--- a/src/atmosphere.jl
+++ b/src/atmosphere.jl
@@ -33,7 +33,7 @@ module atmosphere
     import ..spectrum
 
     # Constants
-    const AGNI_VERSION::String    = "1.7.11"  # current agni version
+    const AGNI_VERSION::String    = "1.7.12"  # current agni version
     const HYDROGRAV_STEPS::Int64  = 40       # num of sub-layers in hydrostatic integration
     const SOCVER_minimum::Float64 = 2407.2   # minimum required socrates version
 

--- a/src/energy.jl
+++ b/src/energy.jl
@@ -449,11 +449,11 @@ module energy
         fill!(atmos.w_conv,     0.0)
 
         # Work variables
-        Hp::Float64 = 0.0; λ::Float64 = 0.0; w::Float64 = 0.0
+        Hp::Float64 = 0.0; hgt::Float64 = 0.0
         m1::Float64 = 0.0; m2::Float64 = 0.0; mt::Float64 = 0.0
         grav::Float64 = 0.0; mu::Float64 = 0.0; c_p::Float64 = 0.0; rho::Float64 = 0.0
         ∇_ad::Float64 = 0.0; ∇_pr::Float64 = 0.0; ∇_μ::Float64 = 0.0; staby::Float64 = 0.0
-        hgt::Float64 = 0.0
+
 
         # Loop from bottom upwards (over cell-edges)
         for i in range(start=atmos.nlev_l-1, step=-1, stop=2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -681,6 +681,8 @@ if suite > 15
     @info " "
     @info "Testing model with energy-conserving TP solver"
     cfg = AGNI.open_config(joinpath(TEST_DIR, "test.toml"))
+
+    # check return code is fine
     succ = AGNI.run_from_config(cfg)
     if succ
         @info "Pass"


### PR DESCRIPTION
The most recent versions of AGNI contain a typo in the MLT convection formulation where the characteristic velocity of convection is stored in the wrong variable. This means that the wrong value of convective flux is returned.

This PR fixes the typo and the convection reliably behaves as expected. Closes #149.

Thank you to @OYBDOOO for pointing this out! 

Here, I have added a contributors page to the docs to give thanks to all those who have made suggestions or changes to AGNI during its development.

Version 1.7.12